### PR TITLE
rc-1.0.2

### DIFF
--- a/ansible/action_plugins/beanstalk_deploy.py
+++ b/ansible/action_plugins/beanstalk_deploy.py
@@ -72,7 +72,14 @@ class ActionModule(object):
             bucket_name = args["bucket_name"]
             key_prefix = args["key_prefix"]
             timestamp = str(int(time.time()))
-            keyname = app_name + "-" + app_version + "-" + timestamp
+            if app_url.find('.war') > -1:
+                file_ext = ".war"
+            elif app_url.find('.zip') > -1:
+                file_ext = ".zip"
+            else:
+                file_ext = ""
+                print "Could not determine artifact format from url - not injecting nucleator config!"
+            keyname = app_name + "-" + app_version + "-" + timestamp + file_ext
 
             # See if this is the first deploy to happen after initial beanstalk setup (true
             # if there is only the initial application version). If so we are going to want
@@ -104,8 +111,6 @@ class ActionModule(object):
                 os.system("jar uf %s .ebextensions/%s" % (archive_file_name, config_file_name))
             elif app_url.find('.zip') > -1:
                 os.system("zip -u %s .ebextensions/%s" % (archive_file_name, config_file_name))
-            else:
-                print "Could not determine artifact format from url - not injecting nucleator config!"
 
             os.chdir(current_dir)
 

--- a/ansible/action_plugins/enable_logging.py
+++ b/ansible/action_plugins/enable_logging.py
@@ -1,0 +1,53 @@
+import json
+import boto
+import yaml
+import os
+import time
+
+from boto import s3
+
+from ansible.runner.return_data import ReturnData
+from ansible.utils import parse_kv, template
+from ansible import utils
+
+class ActionModule(object):
+    def __init__(self, runner):
+        self.runner = runner
+
+    def run(self, conn, tmp, module_name, module_args, inject, complex_args=None, **kwargs):
+        
+		try:
+			
+			args = {}
+			if complex_args:
+				args.update(complex_args)
+			args.update(parse_kv(module_args))
+
+			logging_bucket = args["log_bucket"]
+			account_number = args["account_number"]
+			region = args["region"]
+
+			envdict={}
+			if self.runner.environment:
+				env=template.template(self.runner.basedir, self.runner.environment, inject, convert_bare=True)
+				env = utils.safe_eval(env)
+			
+			s3_conn = s3.connect_to_region(region, aws_access_key_id=env.get("AWS_ACCESS_KEY_ID"),
+                    aws_secret_access_key=env.get("AWS_SECRET_ACCESS_KEY"),
+                    security_token=env.get("AWS_SECURITY_TOKEN"))
+
+			bucketName = "elasticbeanstalk-%s-%s" % (region, account_number)
+
+			bucket1 = s3_conn.get_bucket(bucketName)
+			bucket2 = s3_conn.get_bucket(logging_bucket)
+			response = bucket1.enable_logging(bucket2, "ElasticBeanstalkBucket/")
+
+			return ReturnData(conn=conn,
+                comm_ok=True,
+                result=dict(failed=False, changed=False, msg="Logging Enabled"))
+
+		except Exception, e:
+			# deal with failure gracefully
+			result = dict(failed=True, msg=type(e).__name__ + ": " + str(e))
+			return ReturnData(conn=conn, comm_ok=False, result=result)
+

--- a/ansible/beanstalk_provision.yml
+++ b/ansible/beanstalk_provision.yml
@@ -31,3 +31,5 @@
     customer_name: "{{customer_name}}"
     application_url: "https://elasticbeanstalk-samples-{{ cage_names[cage_name]['region'] }}.s3.amazonaws.com/{{sample_keyname}}"
     application_version: "0.0"
+    visibility_timeout: "{{visibility_timeout}}"
+    inactivity_timeout: "{{inactivity_timeout}}"

--- a/ansible/role_specification.yml
+++ b/ansible/role_specification.yml
@@ -15,14 +15,45 @@
 role_specification:
   - role_name: NucleatorBeanstalkServiceRunner
     trust_policy:
-      Version : "2008-10-17"
-      Statement :
-        - Effect : Allow
-          Sid : NucleatorBeanstalkServiceRunnerTrustPolicy
-          Principal :
-            Service : ec2.amazonaws.com
-          Action : sts:AssumeRole
+      Version: "2008-10-17"
+      Statement:
+        - Effect: Allow
+          Sid: NucleatorBeanstalkServiceRunnerTrustPolicy
+          Principal:
+            Service: ec2.amazonaws.com
+          Action: sts:AssumeRole
     access_policies:
+      - policy_name: NucleatorBeanstalkServiceAccessPolicy
+        policy_document:
+          Statement:
+            - Effect: Allow
+              Action:
+                - "dynamodb:PutItem"
+              Resource: '*'
+            - Effect: Allow
+              Action:
+                - "sqs:GetQueueAttributes"
+                - "sqs:SendMessage"
+                - "sqs:ReceiveMessage"
+                - "sqs:DeleteMessage"
+              Resource: arn:aws:sqs:*
+            - Effect: Allow
+              Action:
+                - "cloudwatch:PutMetricAlarm"
+                - "cloudwatch:PutMetricData"
+              Resource: '*'
+            - Effect: Allow
+              Action:
+                - "s3:ListBucket"
+                - "s3:GetObject"
+                - "s3:CreateBucket"
+                - "s3:PutObject"
+                - "s3:GetBucketPolicy"
+                - "s3:PutObjectAcl"
+                - "s3:GetObjectAcl"
+                - "s3:PutBucketPolicy"
+                - "s3:DeleteObject"
+              Resource: arn:aws:s3:::*
   - role_name: NucleatorBeanstalkProvisioner
     trust_policy:
       Version : "2008-10-17"
@@ -37,7 +68,7 @@ role_specification:
         policy_document:
           Statement :
             - Effect: Allow
-              Action: 
+              Action:
                 - "cloudformation:CreateStack"
                 - "cloudformation:UpdateStack"
                 - "cloudformation:DescribeStacks"
@@ -47,7 +78,7 @@ role_specification:
                 - "cloudformation:ListStackResources"
               Resource: arn:aws:cloudformation:*
             - Effect: Allow
-              Action: 
+              Action:
                 - "s3:ListBucket"
                 - "s3:GetObject"
                 - "s3:CreateBucket"
@@ -57,9 +88,12 @@ role_specification:
                 - "s3:GetObjectAcl"
                 - "s3:PutBucketPolicy"
                 - "s3:DeleteObject"
+                - "s3:PutBucketLogging"
+                - "s3:GetBucketAcl"
+                - "s3:PutBucketAcl"
               Resource: arn:aws:s3:::*
             - Effect: Allow
-              Action: 
+              Action:
                 - "ec2:DescribeKeyPairs"
                 - "ec2:DescribeAddresses"
                 - "ec2:CreateSecurityGroup"
@@ -73,13 +107,13 @@ role_specification:
                 - "ec2:DescribeVpcs"
               Resource: '*'
             - Effect: Allow
-              Action: 
+              Action:
                 - "iam:CreateInstanceProfile"
                 - "iam:AddRoleToInstanceProfile"
                 - "iam:PassRole"
               Resource: '*'
             - Effect: Allow
-              Action: 
+              Action:
                 - "elasticbeanstalk:CreateApplication"
                 - "elasticbeanstalk:DescribeApplications"
                 - "elasticbeanstalk:CreateApplicationVersion"
@@ -89,7 +123,7 @@ role_specification:
                 - "elasticbeanstalk:DescribeEnvironments"
               Resource: arn:aws:elasticbeanstalk:*
             - Effect: Allow
-              Action: 
+              Action:
                 - "elasticloadbalancing:CreateLoadBalancer"
                 - "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
                 - "elasticloadbalancing:ConfigureHealthCheck"
@@ -97,7 +131,7 @@ role_specification:
                 - "elasticloadbalancing:DescribeLoadBalancers"
               Resource: '*'
             - Effect: Allow
-              Action: 
+              Action:
                 - "autoscaling:CreateLaunchConfiguration"
                 - "autoscaling:CreateAutoScalingGroup"
                 - "autoscaling:UpdateAutoScalingGroup"
@@ -110,20 +144,27 @@ role_specification:
                 - "autoscaling:DeleteTags"
               Resource: '*'
             - Effect: Allow
-              Action: 
+              Action:
                 - "cloudwatch:PutMetricAlarm"
               Resource: '*'
             - Effect: Allow
-              Action: 
+              Action:
                 - "route53:ListHostedZones"
                 - "route53:ChangeResourceRecordSets"
                 - "route53:GetChange"
               Resource: '*'
             - Effect: Allow
-              Action: 
+              Action:
                 - "rds:DescribeDBInstances"
                 - "rds:CreateDBInstance"
               Resource: '*'
+            - Effect: Allow
+              Action:
+                - "sqs:CreateQueue"
+                - "sqs:SendMessage"
+                - "sqs:ReadMessage"
+                - "sqs:GetQueueAttributes"
+              Resource: arn:aws:sqs:*
 
   - role_name: NucleatorBeanstalkInventoryManager
     trust_policy:
@@ -139,13 +180,13 @@ role_specification:
         policy_document:
           Statement :
             - Effect: Allow
-              Action: 
+              Action:
                 - "ec2:DescribeInstances"
                 - "ec2:DescribeVolumes"
-                - "ec2:DescribeSnapshots"  
+                - "ec2:DescribeSnapshots"
                 - "ec2:CreateTags"
                 - "ec2:DescribeTags"
-              Resource: '*'      
+              Resource: '*'
   - role_name: NucleatorBeanstalkDeployer
     trust_policy:
       Version : "2008-10-17"
@@ -160,7 +201,7 @@ role_specification:
         policy_document:
           Statement :
             - Effect: Allow
-              Action: 
+              Action:
                 - "ec2:DescribeInstances"
                 - "ec2:TerminateInstances"
                 - "ec2:DescribeSecurityGroups"
@@ -170,13 +211,14 @@ role_specification:
                 - "ec2:DescribeKeyPairs"
               Resource: '*'
             - Effect: Allow
-              Action: 
+              Action:
                 - "cloudformation:GetTemplate"
                 - "cloudformation:UpdateStack"
                 - "cloudformation:DescribeStacks"
                 - "cloudformation:DescribeStackEvents"
                 - "cloudformation:DescribeStackResource"
                 - "cloudformation:DescribeStackResources"
+                - "cloudformation:ListStackResources"
               Resource: arn:aws:cloudformation:*
             - Effect: Allow
               Action:
@@ -187,9 +229,9 @@ role_specification:
                 - "s3:GetBucketPolicy"
                 - "s3:PutObjectAcl"
                 - "s3:DeleteObject"
-              Resource: arn:aws:s3:::* 
+              Resource: arn:aws:s3:::*
             - Effect: Allow
-              Action: 
+              Action:
                 - "elasticbeanstalk:DescribeApplicationVersions"
                 - "elasticbeanstalk:CreateApplicationVersion"
                 - "elasticbeanstalk:UpdateEnvironment"
@@ -207,7 +249,7 @@ role_specification:
                 - "autoscaling:DeleteTags"
               Resource: '*'
             - Effect: Allow
-              Action: 
+              Action:
                 - "elasticloadbalancing:DescribeLoadBalancers"
               Resource: '*'
   - role_name: NucleatorBeanstalkDeleter
@@ -224,7 +266,7 @@ role_specification:
         policy_document:
           Statement :
             - Effect : Allow
-              Action: 
+              Action:
                 - "cloudformation:DescribeStacks"
                 - "cloudformation:DeleteStack"
                 - "cloudformation:DescribeStackEvents"
@@ -286,3 +328,7 @@ role_specification:
                 - "rds:DescribeDBInstances"
                 - "rds:DeleteDBInstance"
               Resource: '*'
+            - Effect: Allow
+              Action:
+                - "sqs:DeleteQueue"
+              Resource: arn:aws:sqs:*

--- a/ansible/role_specification.yml
+++ b/ansible/role_specification.yml
@@ -129,6 +129,7 @@ role_specification:
                 - "elasticloadbalancing:ConfigureHealthCheck"
                 - "elasticloadbalancing:ModifyLoadBalancerAttributes"
                 - "elasticloadbalancing:DescribeLoadBalancers"
+                - "elasticloadbalancing:RegisterInstancesWithLoadBalancer"
               Resource: '*'
             - Effect: Allow
               Action:
@@ -251,6 +252,7 @@ role_specification:
             - Effect: Allow
               Action:
                 - "elasticloadbalancing:DescribeLoadBalancers"
+                - "elasticloadbalancing:RegisterInstancesWithLoadBalancer"
               Resource: '*'
   - role_name: NucleatorBeanstalkDeleter
     trust_policy:

--- a/ansible/roles/beanstalk_provision/tasks/main.yml
+++ b/ansible/roles/beanstalk_provision/tasks/main.yml
@@ -29,6 +29,23 @@
   debug: var=role_credentials
   when: debug_credentials
 
+# The nucleator command parsing checks for proper values; could be incorrect if playbook run directly
+- name: Set paramenters for webserver beanstalk type
+  set_fact:
+    beanstalk_tier: "{{hostvars.localhost.beanstalk_tier_type.frontend}}"
+    beanstalk_dnsrecord: "{{ beanstalk.dnsrecord | to_json_fragment }}"
+    beanstalk_cnameprefix: "{{ beanstalk.cnameprefix | to_json_fragment }}"
+    beanstalk_endpoint: "{{ beanstalk.endpoint | to_json_fragment }}"
+  when: not beanstalk_tiertype_arg is defined or beanstalk_tiertype_arg == 'webserver'
+
+- name: Set paramenters for worker beanstalk type
+  set_fact:
+    beanstalk_tier: "{{hostvars.localhost.beanstalk_tier_type.backend}}"
+    beanstalk_dnsrecord:
+    beanstalk_cnameprefix:
+    beanstalk_endpoint:
+  when: beanstalk_tiertype_arg is defined and beanstalk_tiertype_arg == 'worker'
+
 - name: "provision stackset via cloudformation"
   connection: local
   cloudformation:
@@ -54,6 +71,9 @@
       BeanstalkInstanceType: "{{beanstalk_instance_type}}"
       BeanstalkAutoscaleMinSize: "{{beanstalk_autoscale_min_size}}"
       BeanstalkAutoscaleMaxSize: "{{beanstalk_autoscale_max_size}}"
+      BeanstalkTierName: "{{beanstalk_tier.name}}"
+      BeanstalkTierType: "{{beanstalk_tier.type}}"
+      BeanstalkTierVersion: "{{beanstalk_tier.version}}"
       DatabaseInstanceType: "{{database_instance_type}}"
       DatabaseMultiAZ: "{{database_multi_az}}"
       DatabaseStorage: "{{database_storage}}"
@@ -72,3 +92,11 @@
 - name: show cloudformation output parameters
   action: debug msg="{{create_stackset_stack['stack_outputs']}}"
   when: beanstalk_deleting is not defined or not beanstalk_deleting|bool
+
+- name: Enable Logging on beanstalk s3 bucket
+  enable_logging:
+    log_bucket: "{{nucleator_logging_bucketname_specification}}"
+    region: "{{cage_names[cage_name]['region']}}"
+    account_number: "{{target_account_number}}"
+  environment: role_credentials
+  when: beanstalk_deleting is not defined or not beanstalk_deleting|bool 

--- a/ansible/roles/nucleator_config_setup/templates/nucleator.config
+++ b/ansible/roles/nucleator_config_setup/templates/nucleator.config
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 Resources:
   AWSEBAutoScalingGroup:
     Type: "AWS::AutoScaling::AutoScalingGroup"
@@ -48,30 +47,3 @@ Resources:
           Value:
             Ref: AWSEBEnvironmentId
           PropagateAtLaunch: true
-  AWSEBLoadBalancer:
-    Type: "AWS::ElasticLoadBalancing::LoadBalancer"
-    Properties:
-      Tags:
-        # Nucleator Tag Key / Value Pairs
-        - Key: NucleatorStackset
-          Value: {{stackset_name}}
-        - Key: NucleatorStacksetInstance
-          Value: {{stackset_instance_name}}
-        - Key: NucleatorCustomer
-          Value: {{customer_name}}
-        - Key: NucleatorCage
-          Value: {{cage_name}}
-        - Key: NucleatorGroup
-          Value: beanstalkWorker
-        - Key: Owner
-          Value: {{owner}}
-
-        # DO NOT MODIFY.  Original Elastic Beanstalk Key / Value Pairs.
-        - Key: "elasticbeanstalk:environment-name"
-          Value:
-            Ref: AWSEBEnvironmentName
-        - Key: "Name"
-          Value: {{environment_name | regex_replace('-.*$', '') }}-{{application_name}}.{{cage_name}}.{{customer_domain}}
-        - Key: "elasticbeanstalk:environment-id"
-          Value:
-            Ref: AWSEBEnvironmentId

--- a/ansible/roles/stackset_templates/defaults/main.yml
+++ b/ansible/roles/stackset_templates/defaults/main.yml
@@ -19,5 +19,5 @@ sample_keyname: "elasticbeanstalk-sampleapp.war"
 #configuration_template_description: "AWS Elastic Beanstalk Environment running Python Sample Application"
 configuration_template_description: "AWS Elastic Beanstalk Environment running Java Sample Application"
 
-#configuration_template_solution_stack_name: "64bit Amazon Linux 2014.03 v1.0.7 running Python 2.7"
+#configuration_template_solution_stack_name: "64bit Amazon Linux 2014.03 v1.1.0 running Python 2.7"
 configuration_template_solution_stack_name: "64bit Amazon Linux 2014.09 v1.0.0 running Tomcat 8 Java 8"

--- a/ansible/roles/stackset_templates/templates/beanstalk.j2
+++ b/ansible/roles/stackset_templates/templates/beanstalk.j2
@@ -72,14 +72,29 @@
             "ConstraintDescription": "must be a valid EC2 instance type."
         },
         "BeanstalkAutoscaleMinSize": {
-            "Description": "Maximum size for Beanstalk Autoscaling",
+            "Description": "Minimum size for Beanstalk Autoscaling",
             "Type": "Number",
-            "Default": "2"
+            "Default": "1"
         },
         "BeanstalkAutoscaleMaxSize": {
             "Description": "Maximum size for Beanstalk Autoscaling",
             "Type": "Number",
             "Default": "4"
+        },
+        "BeanstalkTierType": {
+            "Description": "The tier type of this beanstalk: Standard or SQS/HTTP",
+            "Type": "String",
+            "Default": "Standard"
+        },
+        "BeanstalkTierName": {
+            "Description": "The tier name of this beanstalk: Worker or WebServer",
+            "Type": "String",
+            "Default": "WebServer"
+        },
+        "BeanstalkTierVersion": {
+            "Description": "The tier version of this beanstalk",
+            "Type": "String",
+            "Default": "1.0"
         },
         "DatabaseInstanceType": {
             "Description": "RDS EC2 instance type",
@@ -87,7 +102,7 @@
             "Default": "{{default_rds_instance_type}}",
             "AllowedValues": [
                 {{supported_rds_instance_types | to_json_fragment()}},
-		"None"
+                "None"
             ],
             "ConstraintDescription": "must be a valid RDS DB instance type, or \"None\"."
         },
@@ -152,14 +167,14 @@
 	}
     },
     "Resources": {
-    	"InstanceProfile" : {
-	    "Type" : "AWS::IAM::InstanceProfile",
-	    "Condition" : "CreateInstanceProfile",
-	    "Properties" : {
-		"Path" : "/",
-		"Roles" : { "Ref": "ServiceRole" }
-	    }
-	},
+        "InstanceProfile" : {
+            "Type" : "AWS::IAM::InstanceProfile",
+            "Condition" : "CreateInstanceProfile",
+            "Properties" : {
+                "Path" : "/",
+                "Roles" : { "Ref": "ServiceRole" }
+            }
+        },
         "BeanstalkSecurityGroup": {
             "Type": "AWS::EC2::SecurityGroup",
             "Properties": {
@@ -195,7 +210,7 @@
                 ]
             }
         },
-	{{ beanstalk.cage_extension_resources | to_json_fragment }},
+        {{ beanstalk.cage_extension_resources | to_json_fragment }},
         "BeanstalkNatSecurityGroupFtpIngress": {
             "Type": "AWS::EC2::SecurityGroupIngress",
             "Properties": {
@@ -249,11 +264,11 @@
                             {
                                 "Ref": "ApplicationName"
                             },
-			    "{{cage_name}}",
-			    "{{customer_name}}"
+                            "{{cage_name}}",
+                            "{{customer_name}}"
                         ]
                     ]
-		},
+		        },
                 "Description": {
                     "Fn::Join": [
                         "-",
@@ -296,6 +311,16 @@
 		"Description": "{{configuration_template_description}}",
 		"SolutionStackName": "{{configuration_template_solution_stack_name}}",
 		"OptionSettings": [
+                     {
+            "Namespace": "aws:elasticbeanstalk:sqsd",
+            "OptionName": "InactivityTimeout",
+            "Value": "{{inactivity_timeout}}"
+                     },
+                     {
+            "Namespace": "aws:elasticbeanstalk:sqsd",
+            "OptionName": "VisibilityTimeout",
+            "Value": "{{visibility_timeout}}"
+                    },
                     {
 			"Namespace": "aws:elasticbeanstalk:application:environment",
 			"OptionName": "DB_USERNAME",
@@ -407,6 +432,14 @@
 			"OptionName": "DBSubnets",
 			"Value": { "Fn::If":  [ "CreateDatabaseResources", {"Ref" : "DatabaseSubnetGroupId"}, {"Ref" : "AWS::NoValue"}] }
                     }
+            {% if queue_url is defined %}
+            ,
+                {
+                    "Namespace": "aws:elasticbeanstalk:sqsd",
+                    "OptionName": "WorkerQueueURL",
+                    "Value": "{{ queue_url }}"
+                }
+            {% endif %}
 		]
 	    }
         },
@@ -429,46 +462,21 @@
                         ]
                     ]
                 },
+                "Tier" : {
+                  "Type" : { "Ref": "BeanstalkTierType" },
+                  "Name" : { "Ref": "BeanstalkTierName" },
+                  "Version" : { "Ref": "BeanstalkTierVersion" }
+                },
                 "TemplateName": { "Ref": "{{configuration_template_name}}" },
-                "VersionLabel": { "Ref": "SampleVersion" },
-                "CNAMEPrefix": {
-                    "Fn::Join": [
-                        "-",
-                        [
-                            "elb",
-                            {
-                                "Ref": "ApplicationName"
-                            },
-                            {
-                                "Ref": "CageName"
-                            },
-                            "{{customer_domain | replace(".", "-")}}"
-                        ]
-                    ]
-                }
+                {% if beanstalk_cnameprefix is defined %}
+                    {{ beanstalk_cnameprefix }},
+                {% endif %}
+                "VersionLabel": { "Ref": "SampleVersion" }
             }
         },
-
-
-        "BeanstalkDnsRecord": {
-            "Type": "AWS::Route53::RecordSet",
-            "Properties": {
-                "HostedZoneName": "{{ cage_name }}.{{customer_domain}}.",
-                "Comment": "A record for beanstalk instance.",
-                "Name": "{{application_name}}.{{cage_name}}.{{customer_domain}}",
-                "Type": "CNAME",
-                "TTL": "300",
-                "ResourceRecords": [
-                    {
-                		"Fn::GetAtt": [
-                    		"BeanstalkEnv",
-                    		"EndpointURL"
-                		]
-            		}
-                ]
-            }
-        },
-
+        {% if beanstalk_dnsrecord is defined %}
+            {{ beanstalk_dnsrecord }},
+        {% endif %}
         "DatabaseSecurityGroup": {
             "Type": "AWS::EC2::SecurityGroup",
             "Condition" : "CreateDatabaseResources",
@@ -526,7 +534,7 @@
                         "Key": "NucleatorGroup",
                         "Value": "NucleatorBeanstalk"
                     },
-        		    {{ nucleator_common_tags | to_json_fragment }}
+                    {{ nucleator_common_tags | to_json_fragment }}
                 ]
             }
         },
@@ -670,15 +678,9 @@
                 ]
             }
         },
-        "BeanstalkEndpoint": {
-            "Description": "Endpoint for the Beanstalk Environment",
-            "Value": {
-                "Fn::GetAtt": [
-                    "BeanstalkEnv",
-                    "EndpointURL"
-                ]
-            }
-        },
+        {% if beanstalk_endpoint is defined %}
+            {{ beanstalk_endpoint }},
+        {% endif %}
         "BeanstalkSecurityGroupId": {
             "Description": "Id of security group that includes all beanstalk instances",
             "Value": {

--- a/ansible/roles/stackset_templates/vars/beanstalk.yml
+++ b/ansible/roles/stackset_templates/vars/beanstalk.yml
@@ -47,3 +47,37 @@ beanstalk:
         ToPort: "443"
         CidrIp: "0.0.0.0/0"
 #        DestinationSecurityGroupId: "{{nat_security_group_id_macro}}"
+
+  cnameprefix:
+    CNAMEPrefix:
+      'Fn::Join':
+          - "-"
+          -
+            - elb
+            -
+                "Ref": "ApplicationName"
+            -
+                "Ref": "CageName"
+            - "{{customer_domain | replace('.', '-')}}"
+
+  dnsrecord:
+    BeanstalkDnsRecord:
+      Type: "AWS::Route53::RecordSet"
+      Properties:
+        HostedZoneName: "{{ cage_name }}.{{customer_domain}}."
+        Comment: "A record for beanstalk instance."
+        Name: "{{application_name}}.{{cage_name}}.{{customer_domain}}"
+        Type: "CNAME"
+        TTL: "300"
+        ResourceRecords:
+          - "Fn::GetAtt":
+            - "BeanstalkEnv"
+            - "EndpointURL"
+
+  endpoint:
+    BeanstalkEndpoint:
+      Description: "Endpoint for the Beanstalk Environment"
+      Value:
+          "Fn::GetAtt":
+            - "BeanstalkEnv"
+            - "EndpointURL"

--- a/commands/beanstalk.py
+++ b/commands/beanstalk.py
@@ -24,11 +24,11 @@ class Beanstalk(Command):
     name = "beanstalk"
     
     beanstalk_types = {
-        "python" : ("64bit Amazon Linux 2014.03 v1.1.0 running Python 2.7", 
+        "python" : ("64bit Amazon Linux 2015.03 v2.0.0 running Python 2.7", 
                     "AWS Elastic Beanstalk Environment running Python Sample Application"),
-        "java" :   ("64bit Amazon Linux 2014.09 v1.1.0 running Tomcat 8 Java 8",
+        "java" :   ("64bit Amazon Linux 2015.03 v2.0.0 running Tomcat 8 Java 8",
                      "AWS Elastic Beanstalk Environment running Java Sample Application"),
-        "nodejs" : ("64bit Amazon Linux 2014.09 v1.2.1 running Node.js",
+        "nodejs" : ("64bit Amazon Linux 2015.03 v2.0.0 running Node.js",
                     "AWS Elastic Beanstalk Environment running NodeJs Sample Application")
     }
     

--- a/commands/beanstalk.py
+++ b/commands/beanstalk.py
@@ -20,18 +20,18 @@ from nucleator.cli import ansible
 import os, subprocess, re, hashlib
 
 class Beanstalk(Command):
-    
+
     name = "beanstalk"
-    
+
     beanstalk_types = {
-        "python" : ("64bit Amazon Linux 2015.03 v2.0.0 running Python 2.7", 
+        "python" : ("64bit Amazon Linux 2015.03 v2.0.1 running Python 2.7",
                     "AWS Elastic Beanstalk Environment running Python Sample Application"),
         "java" :   ("64bit Amazon Linux 2015.03 v2.0.0 running Tomcat 8 Java 8",
                      "AWS Elastic Beanstalk Environment running Java Sample Application"),
         "nodejs" : ("64bit Amazon Linux 2015.03 v2.0.0 running Node.js",
                     "AWS Elastic Beanstalk Environment running NodeJs Sample Application")
     }
-    
+
     sample_app_keys = {
         "python" : "basicapp.zip",
         "java" : "elasticbeanstalk-sampleapp.war",
@@ -87,8 +87,8 @@ class Beanstalk(Command):
 
     def provision(self, **kwargs):
         """
-        This command provisions a new named Elastic Beanstalk instance in the indicated 
-        customer cage. 
+        This command provisions a new named Elastic Beanstalk instance in the indicated
+        customer cage.
         """
         cli = Command.get_cli(kwargs)
         cage = kwargs.get("cage", None)
@@ -104,13 +104,13 @@ class Beanstalk(Command):
         bstype = kwargs.get("type", None)
         if not bstype in self.beanstalk_types.keys():
             raise ValueError("unsupported beanstalk type")
-        
+
         extra_vars["sample_keyname"] = self.sample_app_keys[bstype]
-        
+
         kind, desc = self.beanstalk_types[bstype]
         extra_vars["configuration_template_solution_stack_name"] = kind
         extra_vars["configuration_template_description"] = desc
-        
+
         basename = kwargs.get("app_name", None)
         if not basename:
             raise ValueError("invalid beanstalk name")
@@ -125,9 +125,9 @@ class Beanstalk(Command):
         namespaced_envname="{0}-{1}-{2}".format(envname, cage, customer)
         namespaced_envname = self.safe_hashed_name(namespaced_envname, 23)
         extra_vars["environment_name"] = namespaced_envname
-        
+
         self.validate_names(namespaced_app_name, namespaced_envname)
-        
+
         for name in ("beanstalk_instance_type", "database_instance_type", "database_name", "database_user", "database_password"):
             value = kwargs.get(name, None)
             if value is not None:
@@ -144,7 +144,7 @@ class Beanstalk(Command):
 
         print "inactivity_timeout = ", extra_vars["inactivity_timeout"]
         print "visibility_timeout = ", extra_vars["visibility_timeout"]
-        
+
         extra_vars["service_role"] = "NucleatorBeanstalkServiceRunner"
         if kwargs.get("service_role", None) is not None:
             extra_vars["service_role"] = kwargs.get("service_role")
@@ -182,7 +182,7 @@ class Beanstalk(Command):
 
         if maxscale < minscale:
             raise ValueError("maxscale must be equal to or greater than minscale")
-        
+
         extra_vars["beanstalk_autoscale_min_size"] = str(minscale)
         extra_vars["beanstalk_autoscale_max_size"] = str(maxscale)
 
@@ -198,13 +198,13 @@ class Beanstalk(Command):
             playbook = "beanstalk_delete.yml"
 
         cli.obtain_credentials(commands = command_list, cage=cage, customer=customer, verbosity=kwargs.get("verbosity", None))
-        
+
         return cli.safe_playbook(self.get_command_playbook(playbook),
                                  inventory_manager_rolename,
-                                 is_static=True, # dynamic inventory not required 
+                                 is_static=True, # dynamic inventory not required
                                  **extra_vars
         )
-    
+
     def safe_hashed_name(self, value, max):
         length = len(value)
         if length < max:
@@ -212,7 +212,7 @@ class Beanstalk(Command):
         trunc = value[:max - 6]
         hashed = hashlib.md5(value).hexdigest()
         return trunc + hashed[:6]
-    
+
     def validate_names(self, bsname, envname):
         alphanum = re.compile("^[a-zA-Z0-9-]*$")
         if len(bsname) > 99 or bsname.find('/') > -1:
@@ -223,10 +223,10 @@ class Beanstalk(Command):
             raise ValueError("Invalid namespaced beanstalk environment name {0} (must be < 23 characters and not contain a / character)".format(envname))
         if alphanum.match(envname) is None:
             raise ValueError("Invalid namespaced environment name {0} (must contain only alphanumeric characters and dashes)".format(envname))
-    
+
     def configure(self, **kwargs):
         """
-        This command configures a named Elastic Beanstalk instance that has been provisioned 
+        This command configures a named Elastic Beanstalk instance that has been provisioned
         in the indicated customer cage.
         """
         cli = Command.get_cli(kwargs)
@@ -246,14 +246,14 @@ class Beanstalk(Command):
             extra_vars["cli_stackset_name"] = "beanstalk"
             extra_vars["cli_stackset_instance_name"] = namespaced_app_name
             extra_vars["application_name"] = basename
-        
+
         command_list = []
         command_list.append("beanstalk")
 
         inventory_manager_rolename = "NucleatorBeanstalkInventoryManager"
 
         cli.obtain_credentials(commands = command_list, cage=cage, customer=customer, verbosity=kwargs.get("verbosity", None)) # pushes credentials into environment
-        
+
         return cli.safe_playbook(
             self.get_command_playbook("beanstalk_configure.yml"),
             inventory_manager_rolename,
@@ -262,7 +262,7 @@ class Beanstalk(Command):
 
     def deploy(self, **kwargs):
         """
-        This command deploys a particular revision of an application to a provisioned 
+        This command deploys a particular revision of an application to a provisioned
         Elastic Beanstalk instance running in the indicated customer cage.
         """
         cli = Command.get_cli(kwargs)
@@ -279,7 +279,7 @@ class Beanstalk(Command):
         for name in ("app_name", "app_version"):
             if not kwargs.get(name, None):
                 raise ValueError("%s must be specified" % name)
-        
+
         basename=kwargs.get("app_name")
         namespaced_app_name="{0}-{1}-{2}".format(basename, cage, customer)
         namespaced_app_name = self.safe_hashed_name(namespaced_app_name, 100)
@@ -302,7 +302,7 @@ class Beanstalk(Command):
         inventory_manager_rolename = "NucleatorBeanstalkDeployer"
 
         cli.obtain_credentials(commands = command_list, cage=cage, customer=customer, verbosity=kwargs.get("verbosity", None)) # pushes credentials into environment
-        
+
         return cli.safe_playbook(
             self.get_command_playbook("beanstalk_deploy.yml"),
             inventory_manager_rolename,
@@ -312,7 +312,7 @@ class Beanstalk(Command):
     def delete(self, **kwargs):
         """
         This command deletes the specified, previously provisioned Elastic Beanstalk instance from the indicated
-        customer cage. 
+        customer cage.
         """
         kwargs["beanstalk_deleting"]=True
         kwargs["type"]="java" # type must be specified to leverage provision, although its value is a don't care

--- a/commands/beanstalk.py
+++ b/commands/beanstalk.py
@@ -23,9 +23,8 @@ class Beanstalk(Command):
     
     name = "beanstalk"
     
-    
     beanstalk_types = {
-        "python" : ("64bit Amazon Linux 2014.03 v1.0.7 running Python 2.7", 
+        "python" : ("64bit Amazon Linux 2014.03 v1.1.0 running Python 2.7", 
                     "AWS Elastic Beanstalk Environment running Python Sample Application"),
         "java" :   ("64bit Amazon Linux 2014.09 v1.1.0 running Tomcat 8 Java 8",
                      "AWS Elastic Beanstalk Environment running Java Sample Application"),
@@ -53,6 +52,7 @@ class Beanstalk(Command):
         beanstalk_provision.add_argument("--cage", required=True, help="Name of cage from nucleator config")
         beanstalk_provision.add_argument("--type", required=True, help="Type of beanstalk to provision (python or java)")
         beanstalk_provision.add_argument("--app_name", required=True, help="Name of beanstalk application to provision")
+        beanstalk_provision.add_argument("--tier", required=False, help="Tier of beanstalk to provision (webserver or worker)")
         beanstalk_provision.add_argument("--beanstalk_instance_type", required=False, help="EC2 instance type to provision")
         beanstalk_provision.add_argument("--database_instance_type", required=False, help="Database instance type to provision (default: None)")
         beanstalk_provision.add_argument("--database_name", required=False, help="Name of database to provision")
@@ -61,6 +61,9 @@ class Beanstalk(Command):
         beanstalk_provision.add_argument("--minscale", required=False, help="Minimum size of autoscaling group (default 1)")
         beanstalk_provision.add_argument("--maxscale", required=False, help="Maximum size of autoscaling group (default 4)")
         beanstalk_provision.add_argument("--service_role", required=False, help="Role to associate with instance profile (default NucleatorBeanstalkServiceRunner)")
+        beanstalk_provision.add_argument("--queue_url", required=False, help="URL of the queue for the worker tier application to use instead of creating its own")
+        beanstalk_provision.add_argument("--inactivity_timeout", required=False, help="Number of seconds for the inactivity timeout")
+        beanstalk_provision.add_argument("--visibility_timeout", required=False, help="Number of seconds for the visibility timeout")
 
         # configure subcommand
         beanstalk_configure=beanstalk_subparsers.add_parser('configure', help="configure provisioned nucleator beanstalk stackset")
@@ -131,6 +134,16 @@ class Beanstalk(Command):
                 extra_vars[name] = value
 
         extra_vars["beanstalk_deleting"]=kwargs.get("beanstalk_deleting", False)
+
+        extra_vars["inactivity_timeout"]=kwargs.get("inactivity_timeout")
+        if extra_vars["inactivity_timeout"] is None:
+            extra_vars["inactivity_timeout"] = 180
+        extra_vars["visibility_timeout"]=kwargs.get("visibility_timeout")
+        if extra_vars["visibility_timeout"] is None:
+            extra_vars["visibility_timeout"] = 30
+
+        print "inactivity_timeout = ", extra_vars["inactivity_timeout"]
+        print "visibility_timeout = ", extra_vars["visibility_timeout"]
         
         extra_vars["service_role"] = "NucleatorBeanstalkServiceRunner"
         if kwargs.get("service_role", None) is not None:
@@ -153,6 +166,19 @@ class Beanstalk(Command):
                 maxscale = int(maxscale)
             except ValueError:
                 raise ValueError("maxscale must be an integer")
+
+        tier = kwargs.get("tier", None)
+        if tier is not None:
+            if tier == 'worker' or tier == 'webserver':
+                extra_vars["beanstalk_tiertype_arg"] = tier
+            else:
+                ValueError("tier must be 'worker' or 'webserver'")
+
+        queue_url = kwargs.get("queue_url", None)
+        if queue_url is not None:
+            if tier != 'worker':
+                ValueError("queue_url is only used when tier is 'worker'")
+            extra_vars["queue_url"] = queue_url
 
         if maxscale < minscale:
             raise ValueError("maxscale must be equal to or greater than minscale")


### PR DESCRIPTION
Includes:

RS-568 Include version info upon nucleator update, add --version to report on currently installed versions
RS-665 Security hardening based on potential issues identified by CloudCheckr
RS-526 Enhance validation of siteconfig
RS-586 Support worker tier beanstalks
47lining/nucleator-core-redshift#1 Improved Support for Private Redshift Clusters
SSL process and documentation improvements for builder
Use ansible inventory mantained in ~/.nucleator for stronger stackset and end-user ease-of-use
